### PR TITLE
Swaps GitHub endpoint for Google API endpoint

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -47,7 +47,7 @@ get_download_url() {
   local version=$1
   local filename="$(get_filename)"
 
-  echo "https://github.com/kubernetes/minikube/releases/download/v${version}/${filename}"
+  echo "https://storage.googleapis.com/minikube/releases/v${version}/${filename}"
 }
 
 install_minikube $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH


### PR DESCRIPTION
GitHub endpoint does not work with cURL, pressumably due to change in API (see: https://developer.github.com/v3/repos/releases/\#get-a-single-release-asset). Uses Google one instead.