### PR TITLE
Pin asdf version to 0.5.0 in travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c
 script: asdf plugin-test minikube .
 before_script:
-  - git clone https://github.com/asdf-vm/asdf.git
+  - git clone --branch v0.5.0 https://github.com/asdf-vm/asdf.git
   - . asdf/asdf.sh
 os:
   - linux


### PR DESCRIPTION
There is a problem running plugin tests.
Related issue: https://github.com/asdf-vm/asdf/issues/373