### PR TITLE
parsing github releases in a osx friendly way

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -14,5 +14,5 @@ function sort_versions() {
 }
 
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval $cmd | grep -oE "tag_name\":\s?\".{1,15}\"," | sed -E 's/tag_name\":\s?\"v([0-9\.]+)\",/\1/'| sort_versions)
+versions=$(eval $cmd | grep -oE "tag_name\":\s?\".{1,15}\"," | awk -F\" '{sub(/v/, "", $3); print $3;}' | sort_versions)
 echo $versions


### PR DESCRIPTION
For some reason the `sed` in the list-all does not work with the version of `sed` installed on OSX (at least for the latest version).

I am pretty sure this awk will work with most all BSD / Linux systems.