### PR TITLE
fix version sorting

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -10,7 +10,7 @@ cmd="$cmd $releases_path"
 # stolen from https://github.com/rbenv/ruby-build/pull/631/files#diff-fdcfb8a18714b33b07529b7d02b54f1dR942
 function sort_versions() {
   sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' | \
-    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
+    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}' | cut -d'v' -f2 | cut -d'"' -f1
 }
 
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.


### PR DESCRIPTION
Currently the list-all function returns an incorrect version string

```
$ asdf list-all minikube
"v0.19.0",.z
"v0.19.1",.z
"v0.20.0",.z
"v0.21.0",.z
```

With the my change the output is:

```
$ asdf list-all minikube
"v0.19.0",
"v0.19.1",
"v0.20.0",
"v0.21.0",
```