### PR TITLE
fix list-all to get correct versions

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -14,5 +14,5 @@ function sort_versions() {
 }
 
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval $cmd | grep -oE "tag_name\":\s?\".{1,15}\"," | sed -E 's/tag_name\":\s?\"v([0-9\.]+)\",/\1/'| sort_versions)
+versions=$(eval $cmd | sed -nE 's/[ \s]+"tag_name":[ \s]*"v(.*)",/\1/p' | sort_versions)
 echo $versions


### PR DESCRIPTION
Currently, we couldn't get all versions for downloading with `install` script.
This PR fix list-all script to get all versions and can run `asdf latest minikube` correctly.

This PR will also fix #10 and #8.

In results, I got below versions list.
```
$ asdf list all minikube
0.28.2
0.29.0
0.30.0
0.31.0
0.32.0
0.33.0
0.33.1
0.34.0
0.34.1
0.35.0
1.0.0
1.0.1
1.1.0
1.1.1
1.2.0
1.3.0
1.3.1
1.4.0-beta.0
1.4.0-beta.1
1.4.0-beta.2
1.4.0
1.5.0-beta.0
1.5.0
1.5.1
1.5.2
1.6.0-beta.0
1.6.0-beta.1
1.6.0
1.6.1
1.6.2
```