### PR TITLE
Rename global variable for github token

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -2,8 +2,8 @@
 
 releases_path=https://api.github.com/repos/kubernetes/minikube/releases
 cmd="curl -s"
-if [ -n "$OAUTH_TOKEN" ]; then
-  cmd="$cmd -H 'Authorization: token $OAUTH_TOKEN'"
+if [ -n "$GITHUB_API_TOKEN" ]; then
+  cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
 fi
 cmd="$cmd $releases_path"
 


### PR DESCRIPTION
Many asdf plugin use github token to avoid github rate limit with GITHUB_API_TOKEN variable.
I think this plugin should use GITHUB_API_TOKEN too for users.