### PR TITLE
Add support for ARM binaries

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -22,7 +22,7 @@ install_minikube() {
     esac
 
     if [ "$arch" = "other" ]; then
-        echo "Unsupported architecture $(uname -m). Only x64 binaries are available."
+        echo "Unsupported architecture $(uname -m). Only x64 and ARM binaries are available."
         exit
     fi
 

--- a/bin/install
+++ b/bin/install
@@ -17,6 +17,7 @@ install_minikube() {
 
     case $(uname -m) in
     x86_64) arch="amd64" ;;
+    arm64) arch="arm64" ;;
     *) arch="other" ;;
     esac
 
@@ -25,7 +26,7 @@ install_minikube() {
         exit
     fi
 
-    download="https://github.com/kubernetes/minikube/releases/download/v${install_version}/minikube-${os}-amd64"
+    download="https://github.com/kubernetes/minikube/releases/download/v${install_version}/minikube-${os}-${arch}"
     filename="${install_path}/bin/minikube"
 
     if [ ! -d "${install_path}/bin" ]; then


### PR DESCRIPTION
Noticed that the output of `uname -m` isn't used in the download URL. Tested with my fork on an M1 Mac. Sorry for the closed PR #16 - forgot I was on a separate branch there.