### PR TITLE
Add `aarch64` to the list of valid architectures

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -18,6 +18,7 @@ install_minikube() {
     case $(uname -m) in
     x86_64) arch="amd64" ;;
     arm64) arch="arm64" ;;
+    aarch64) arch="arm64" ;;
     *) arch="other" ;;
     esac
 


### PR DESCRIPTION
Problem
=======

* I have an M1 Mac, running UTM, running qemu, running arm64 version of Ubuntu. `arm64` version of minikube runs on this set up, however `asdf-minikube` does not let me install it because it specifically looks for `arm64` architecture whereas in this vm reported architecture is `aarch64`.

Solution
========

* Add `aarch64` to the list of accepted architectures.